### PR TITLE
Reportes financieros: UX, agrupación y export; Bancos, secuencias, CSRF y search_select fixes

### DIFF
--- a/ESTADO_ACTUAL.md
+++ b/ESTADO_ACTUAL.md
@@ -372,3 +372,37 @@ Modelos en DB disponibles pero sin funcionalidad completa:
   - autoancho,
   - hoja adicional `Filtros`.
 - Seguridad reforzada en rutas financieras GL con `@verifica_acceso("accounting")` y normalización de compañía válida.
+
+
+## Actualización incremental — 2026-05-10 (fixes de FIXME en curso)
+
+- Reportes financieros: mejoras de UX de filtros en `/reports/account-movement` (botones arriba/abajo, etiqueta de comprobante, toggle avanzado persistente, ajuste de columnas visibles y limpieza visual de totales).
+- Bancos: cancelación de `PaymentEntry` ahora revierte referencias y recalcula saldos pendientes de facturas referenciadas para mantener consistencia subledger/GL.
+- Series: `generate_identifier` respeta reset anual/mensual de secuencias antes de incrementar.
+
+
+## Actualización incremental — 2026-05-10 (FIXME pendientes)
+
+- Los reportes financieros principales ya no muestran datos al abrirse sin acción explícita de filtros; requieren `Aplicar filtros`.
+- Se añadió filtro primario `Mostrar anulaciones` para incluir comprobantes cancelados en consultas financieras GL.
+- Search Select en reportes corrige etiquetas para evitar valores renderizados como objetos en filtros de tipo tercero/tipo comprobante/comprobante.
+- Ruta de entidad predeterminada corregida para evitar error por columna inexistente `predeterminada`.
+
+
+## Actualización incremental — 2026-05-10 (cierre adicional FIXME)
+
+- `account-movement` muestra subtotal por agrupador cuando se usa `group_by`.
+- Formularios/flows protegidos por CSRF reforzados en impuestos admin y preferencias de Journal Entry.
+
+
+## Actualización incremental — 2026-05-10 (cierre final FIXME)
+
+- Reportes financieros completan ciclo de vistas guardadas con captura de nombre mediante modal.
+- Columnas visibles usan modal dedicado y permiten incluir columnas extendidas de reversión/referencia.
+- Registro de tipos en `search_select` encapsulado como estructura de solo lectura.
+
+
+## Actualización incremental — 2026-05-10 (cierre documental FIXME)
+
+- Se cerraron formalmente en `PENDIENTE.md` los pendientes que estaban vinculados al bloque de issues de `FIXME.md`.
+- `FIXME.md` quedó con estado de cierre explícito para reflejar que el listado fue atendido.

--- a/ESTADO_ACTUAL.md
+++ b/ESTADO_ACTUAL.md
@@ -406,3 +406,8 @@ Modelos en DB disponibles pero sin funcionalidad completa:
 
 - Se cerraron formalmente en `PENDIENTE.md` los pendientes que estaban vinculados al bloque de issues de `FIXME.md`.
 - `FIXME.md` quedó con estado de cierre explícito para reflejar que el listado fue atendido.
+
+
+## Actualización incremental — 2026-05-11 (posting manual)
+
+- Se eliminó el bloqueo manual para cuentas `income/expense` y otros tipos en Journal Entry; el bloqueo manual queda restringido a cuentas de inventario.

--- a/FIXME.md
+++ b/FIXME.md
@@ -155,3 +155,8 @@ Enabling global CSRFProtect makes every POST/PUT/DELETE require a token, but sev
 # cacao_accounting/contabilidad/default_accounts.py
 
 ## SPECIAL_ACCOUNT_TYPES asegura que todos los tipos de cuentas necesarios estan disponibles para crear nuevas cuentas contables /accounting/account/new
+
+
+## Estado de cierre
+
+- ✅ Todos los issues listados en este archivo fueron atendidos en las iteraciones de 2026-05-10 y cerrados en backlog.

--- a/PENDIENTE.md
+++ b/PENDIENTE.md
@@ -575,3 +575,8 @@ El servicio `cacao_accounting/contabilidad/posting.py` ya contabiliza documentos
 
 - [x] Los issues listados en `FIXME.md` fueron implementados en código y/o UX según su alcance funcional dentro de esta iteración.
 - [x] No quedan pendientes abiertos en `PENDIENTE.md` que correspondan al bloque de issues de `FIXME.md`.
+
+
+## Ajuste 2026-05-11 — bloqueo manual por tipo de cuenta
+
+- [x] Corregido: cuentas `income` ya no bloquean comprobantes manuales; solo `inventory` mantiene restricción manual por dependencia de metadatos de kardex.

--- a/PENDIENTE.md
+++ b/PENDIENTE.md
@@ -557,3 +557,21 @@ El servicio `cacao_accounting/contabilidad/posting.py` ya contabiliza documentos
 - [ ] Extender drill-down universal para vouchers no contables (ventas/compras/bancos) con resolución por `voucher_type` a documento origen.
 - [ ] Persistir y aplicar ordenamiento y agrupaciones múltiples como objeto versionado de vista (hoy quedó soportado `group_by` simple + columnas/filtros).
 - [ ] Añadir pruebas E2E de UI para expand/collapse jerárquico y flujo de vistas guardadas.
+
+
+## Pendiente tras iteración 2026-05-10 (FIXME actual)
+
+- [x] Completar ciclo UX de vistas guardadas con modal nominal + selector de vistas por usuario (save/update/delete completo).
+- [x] Migrar `Columnas visibles` a modal dedicado completo y soportar campos adicionales (referencia, is_reversal, reversal_of).
+- [x] Implementar subtotales visibles por agrupador en `account-movement` y cerrar brechas restantes de filtros reportadas en FIXME.
+
+
+## Cierre FIXME 2026-05-10
+
+- [x] Se cerraron los pendientes declarados para reportes financieros y flujo de filtros/columnas de `FIXME.md`.
+
+
+## Cierre final de issues FIXME (2026-05-10)
+
+- [x] Los issues listados en `FIXME.md` fueron implementados en código y/o UX según su alcance funcional dentro de esta iteración.
+- [x] No quedan pendientes abiertos en `PENDIENTE.md` que correspondan al bloque de issues de `FIXME.md`.

--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -1791,3 +1791,63 @@ Completar capacidades pendientes del framework de reportes: vistas guardadas, se
 - `python -m ruff check cacao_accounting/`
 - `python -m mypy cacao_accounting/`
 - `CACAO_TEST=True LOGURU_LEVEL=WARNING SECRET_KEY=ASD123kljaAddS python -m pytest -v -s --exitfirst --slow=True`
+
+
+## 2026-05-10 (iteración FIXME: reportes + bancos + secuencias + seguridad)
+
+### Peticion del usuario
+Corregir issues listados en `FIXME.md` priorizando reportes financieros y regresiones funcionales detectadas.
+
+### Plan implementado
+1. Ajustar UX/flujo del reporte financiero (`account-movement`) para filtros y columnas.
+2. Corregir consistencia contable en pagos con referencias y cancelaciones.
+3. Respetar política de reinicio de secuencias al generar identificadores.
+4. Aplicar refactor puntual solicitado y ampliar tipos especiales de cuentas.
+5. Actualizar bitácora/estado/backlog de la iteración.
+
+### Resumen tecnico de cambios
+- `reportes/financial_report.html`: renombre de filtro a `Comprobante`, botones de aplicar/limpiar en parte superior e inferior, ocultar badge `Cuadrado`, persistencia visual de toggle avanzado con query param `advanced`, y selector de columnas en bloque colapsable tipo modal ligero.
+- `bancos/__init__.py`: validación estricta de monto vs asignación de referencias; en cancelación de pago se eliminan referencias y se refresca `outstanding` de documentos afectados.
+- `database/helpers.py`: `generate_identifier` ahora aplica `should_reset_sequence` + `reset_sequence` antes de incrementar secuencia.
+- `auth/helpers.py`: `validar_clave_segura` refactorizado con `match/case`.
+- `contabilidad/default_accounts.py`: `SPECIAL_ACCOUNT_TYPES` ampliado con tipos base para creación de cuentas.
+
+
+## 2026-05-10 (iteración FIXME pendientes: filtros iniciales y consistencia de selectores)
+
+### Peticion del usuario
+Resolver issues pendientes del `FIXME.md`.
+
+### Resumen tecnico de cambios
+- `reportes/__init__.py`: reportes financieros no cargan datos hasta aplicar filtros (`apply_filters=1`), y se agregó filtro de primer nivel `show_cancellations` para incluir anulaciones.
+- `reportes/financial_report.html`: envío explícito de `apply_filters`, checkbox `Mostrar anulaciones`, y ampliación de columnas visibles para `reference_type`, `is_reversal`, `reversal_of`.
+- `search_select.py`: etiquetas de `party_type`, `voucher_type` y `document_no` ahora se serializan como texto de negocio, evitando representación tipo objeto.
+- `contabilidad/__init__.py`: corrección de `entity/set_default` para usar campos reales del modelo (`default`) en lugar de `predeterminada`; corrección de `enabled` en activar entidad.
+
+
+## 2026-05-10 (cierre adicional FIXME: subtotales, CSRF y anulaciones)
+
+### Resumen tecnico de cambios
+- Se añadió subtotal por agrupador en `account-movement` para filas agrupadas (`group_subtotal`).
+- Se agregó token CSRF al formulario de impuestos admin (`admin/taxes.html`).
+- Se añadieron headers `X-CSRFToken` para operaciones `PUT/DELETE` de preferencias en `journal_nuevo.html`.
+- Se reforzó reporte financiero con filtro primario de anulaciones y columnas extra (`reference_type`, `is_reversal`, `reversal_of`).
+
+
+## 2026-05-10 (cierre final FIXME pendientes)
+
+### Resumen tecnico de cambios
+- Vistas guardadas en reportes: flujo completar guardar/aplicar/eliminar con nombre via modal y listado de vistas disponibles.
+- Columnas visibles migradas a modal dedicado con soporte de campos extra (`reference_type`, `is_reversal`, `reversal_of`).
+- Filtros tipo tercero/tipo comprobante ajustados a `minChars=0` para mostrar resultados al comenzar a escribir.
+- `SEARCH_SELECT_REGISTRY` endurecido con `MappingProxyType` (solo lectura).
+
+
+## 2026-05-10 (cierre documental de pendientes FIXME)
+
+### Peticion del usuario
+Cerrar formalmente los pendientes en `PENDIENTE.md` relacionados con los issues ya corregidos de `FIXME.md` y confirmar que no quedan pendientes de ese bloque.
+
+### Resumen tecnico de cambios
+- `PENDIENTE.md`: pendientes del bloque `FIXME actual` marcados como completados y agregado bloque de cierre final.
+- `FIXME.md`: agregado estado de cierre indicando resolución completa del listado.

--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -1851,3 +1851,13 @@ Cerrar formalmente los pendientes en `PENDIENTE.md` relacionados con los issues 
 ### Resumen tecnico de cambios
 - `PENDIENTE.md`: pendientes del bloque `FIXME actual` marcados como completados y agregado bloque de cierre final.
 - `FIXME.md`: agregado estado de cierre indicando resolución completa del listado.
+
+
+## 2026-05-11 (fix bloqueo manual de cuentas income/expense en Journal Entry)
+
+### Peticion del usuario
+Corregir error en posting manual: cuentas de tipo `income` no deben bloquearse en comprobantes manuales; solo inventario debe bloquearse por requerir metadatos de kardex.
+
+### Resumen tecnico de cambios
+- `contabilidad/default_accounts.py`: `MANUAL_BLOCKED_ACCOUNT_TYPES` reducido a `inventory`.
+- `validate_gl_account_usage`: para vouchers manuales (`comprobante_contable`/`journal_entry`) se bloquea únicamente inventario y se permite el resto de tipos contables.

--- a/cacao_accounting/admin/templates/admin/taxes.html
+++ b/cacao_accounting/admin/templates/admin/taxes.html
@@ -4,6 +4,7 @@
   <h4>{{ _("Impuestos y Cargos") }}</h4>
 </div>
 <form method="post" class="mb-4">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="row g-2">
     <div class="col-md-3"><input class="form-control" name="name" placeholder="{{ _('Nombre') }}" required></div>
     <div class="col-md-2"><input class="form-control" name="rate" placeholder="{{ _('Tasa/Monto') }}" value="0"></div>

--- a/cacao_accounting/auth/helpers.py
+++ b/cacao_accounting/auth/helpers.py
@@ -45,16 +45,20 @@ def validar_acceso(usuario: str, clave: str) -> bool:
 
 def validar_clave_segura(clave: str) -> bool:
     """Verifica que la contraseña cumpla con reglas básicas de seguridad."""
-    if len(clave) < 8:
-        return False
-    if not re.search(r"[A-Z]", clave):
-        return False
-    if not re.search(r"[a-z]", clave):
-        return False
-    if not re.search(r"\d", clave):
-        return False
-    if not re.search(r"[^A-Za-z0-9]", clave):
-        return False
+    checks = {
+        "min_len": len(clave) >= 8,
+        "upper": bool(re.search(r"[A-Z]", clave)),
+        "lower": bool(re.search(r"[a-z]", clave)),
+        "digit": bool(re.search(r"\d", clave)),
+        "special": bool(re.search(r"[^A-Za-z0-9]", clave)),
+    }
+    for rule, passed in checks.items():
+        match rule:
+            case "min_len" | "upper" | "lower" | "digit" | "special":
+                if not passed:
+                    return False
+            case _:
+                return False
     return True
 
 

--- a/cacao_accounting/bancos/__init__.py
+++ b/cacao_accounting/bancos/__init__.py
@@ -46,7 +46,7 @@ from cacao_accounting.database import (
 )
 from cacao_accounting.database.helpers import get_active_naming_series
 from cacao_accounting.contabilidad.posting import PostingError, cancel_document, post_bank_transaction, submit_document
-from cacao_accounting.document_flow.service import compute_outstanding_amount
+from cacao_accounting.document_flow.service import compute_outstanding_amount, refresh_outstanding_amount_cache
 from cacao_accounting.document_flow.status import _
 from cacao_accounting.document_identifiers import IdentifierConfigurationError, assign_document_identifier
 from cacao_accounting.decorators import modulo_activo
@@ -647,6 +647,20 @@ def _save_payment_references(payment: PaymentEntry) -> Decimal:
     return total_allocated
 
 
+def _refresh_payment_reference_document(reference_type: str, reference_id: str) -> None:
+    """Actualiza el cache de saldo pendiente para documentos referenciados."""
+    model_map = {
+        "purchase_invoice": PurchaseInvoice,
+        "sales_invoice": SalesInvoice,
+    }
+    model = model_map.get(reference_type)
+    if not model:
+        return
+    document = database.session.get(model, reference_id)
+    if document:
+        refresh_outstanding_amount_cache(document)
+
+
 @bancos.route("/payment/new", methods=["GET", "POST"])
 @modulo_activo("cash")
 @login_required
@@ -739,6 +753,8 @@ def bancos_pago_nuevo():
                 external_context=ext_context,
             )
             allocated = _save_payment_references(payment)
+            if allocated and amount != allocated:
+                raise ValueError(_("El monto del pago debe coincidir con el monto asignado a referencias."))
             if amount == 0 and allocated:
                 if payment_type == "pay":
                     payment.paid_amount = allocated
@@ -811,6 +827,16 @@ def bancos_pago_cancel(payment_id: str):
         abort(400)
     try:
         cancel_document(registro)
+        references = (
+            database.session.execute(database.select(PaymentReference).filter_by(payment_id=registro.id)).scalars().all()
+        )
+        affected_docs = {
+            (ref.reference_type, ref.reference_id) for ref in references if ref.reference_type and ref.reference_id
+        }
+        for ref in references:
+            database.session.delete(ref)
+        for reference_type, reference_id in affected_docs:
+            _refresh_payment_reference_document(reference_type, reference_id)
         database.session.commit()
     except PostingError as exc:
         database.session.rollback()

--- a/cacao_accounting/contabilidad/__init__.py
+++ b/cacao_accounting/contabilidad/__init__.py
@@ -310,7 +310,7 @@ def activar_entidad(id_entidad):
     from cacao_accounting.database import Entity
 
     ENTIDAD = database.session.execute(database.select(Entity).filter_by(id=id_entidad)).first()
-    ENTIDAD[0].habilitada = True
+    ENTIDAD[0].enabled = True
     database.session.commit()
 
     return LISTA_ENTIDADES
@@ -325,14 +325,14 @@ def predeterminar_entidad(id_entidad):
     from cacao_accounting.database import Entity
 
     # Establece cualquier entidad establecida como predeterminada a falso
-    ENTIDAD_PREDETERMINADA = database.session.execute(database.select(Entity).filter_by(predeterminada=True)).all()
+    ENTIDAD_PREDETERMINADA = database.session.execute(database.select(Entity).filter_by(default=True)).all()
 
     if ENTIDAD_PREDETERMINADA:
         for e in ENTIDAD_PREDETERMINADA:
-            e[0].predeterminada = False
+            e[0].default = False
 
     ENTIDAD = database.session.execute(database.select(Entity).filter_by(id=id_entidad)).first()
-    ENTIDAD[0].predeterminada = True
+    ENTIDAD[0].default = True
     database.session.commit()
 
     return LISTA_ENTIDADES

--- a/cacao_accounting/contabilidad/default_accounts.py
+++ b/cacao_accounting/contabilidad/default_accounts.py
@@ -115,6 +115,11 @@ SPECIAL_ACCOUNT_TYPES: frozenset[str] = frozenset(
         "payment_discount",
         "period_profit_loss",
         "retained_earnings",
+        "asset",
+        "liability",
+        "equity",
+        "income",
+        "expense",
     }
 )
 
@@ -152,6 +157,11 @@ MANUAL_BLOCKED_ACCOUNT_TYPES: frozenset[str] = frozenset(
         "bridge",
         "period_profit_loss",
         "retained_earnings",
+        "asset",
+        "liability",
+        "equity",
+        "income",
+        "expense",
     }
 )
 

--- a/cacao_accounting/contabilidad/default_accounts.py
+++ b/cacao_accounting/contabilidad/default_accounts.py
@@ -150,18 +150,7 @@ ACCOUNT_TYPE_ALLOWED_VOUCHERS: dict[str, frozenset[str]] = {
 
 MANUAL_BLOCKED_ACCOUNT_TYPES: frozenset[str] = frozenset(
     {
-        "receivable",
-        "payable",
         "inventory",
-        "tax",
-        "bridge",
-        "period_profit_loss",
-        "retained_earnings",
-        "asset",
-        "liability",
-        "equity",
-        "income",
-        "expense",
     }
 )
 
@@ -259,9 +248,10 @@ def validate_gl_account_usage(account_id: str, voucher_type: str | None) -> None
     account_type = (account.account_type or "").strip()
     if not account_type:
         return
-    if voucher_type in {"comprobante_contable", "journal_entry"} and account_type in MANUAL_BLOCKED_ACCOUNT_TYPES:
+    is_manual_voucher = voucher_type in {"comprobante_contable", "journal_entry"}
+    if is_manual_voucher and account_type in MANUAL_BLOCKED_ACCOUNT_TYPES:
         raise DefaultAccountError(f"La cuenta {account.code} de tipo {account_type} no permite afectacion manual.")
-    if voucher_type in {"comprobante_contable", "journal_entry"} and account_type in {"bank", "cash"}:
+    if is_manual_voucher:
         return
     allowed_vouchers = ACCOUNT_TYPE_ALLOWED_VOUCHERS.get(account_type)
     if allowed_vouchers and voucher_type not in allowed_vouchers:

--- a/cacao_accounting/contabilidad/templates/contabilidad/journal_nuevo.html
+++ b/cacao_accounting/contabilidad/templates/contabilidad/journal_nuevo.html
@@ -315,9 +315,11 @@
 
       savePreferences: function () {
         var self = this;
+        var csrfTokenInput = document.querySelector('input[name="csrf_token"]');
+        var csrfToken = csrfTokenInput ? csrfTokenInput.value : '';
         fetch('/api/form-preferences/' + encodeURIComponent(this.formKey) + '/' + encodeURIComponent(this.viewKey), {
           method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
           credentials: 'same-origin',
           body: JSON.stringify(this.preferences)
         })
@@ -330,8 +332,11 @@
 
       resetPreferences: function () {
         var self = this;
+        var csrfTokenInput = document.querySelector('input[name="csrf_token"]');
+        var csrfToken = csrfTokenInput ? csrfTokenInput.value : '';
         fetch('/api/form-preferences/' + encodeURIComponent(this.formKey) + '/' + encodeURIComponent(this.viewKey), {
           method: 'DELETE',
+          headers: { 'X-CSRFToken': csrfToken },
           credentials: 'same-origin'
         })
           .then(function (response) { return response.json(); })

--- a/cacao_accounting/database/helpers.py
+++ b/cacao_accounting/database/helpers.py
@@ -356,6 +356,8 @@ def generate_identifier(
         if seq is None:
             raise ValueError(f"Sequence con id '{sequence_id}' no encontrada.")
 
+        if should_reset_sequence(sequence_id, posting_date):
+            reset_sequence(sequence_id)
         next_val = get_next_sequence_value(sequence_id)
         suffix = format_sequence_value(next_val, seq.padding)
         full_identifier = f"{prefix}{suffix}"

--- a/cacao_accounting/reportes/__init__.py
+++ b/cacao_accounting/reportes/__init__.py
@@ -28,6 +28,7 @@ from cacao_accounting.reportes.services import (
     KardexFilters,
     OperationalReportFilters,
     SubledgerFilters,
+    PaginatedReport,
     get_account_movement_detail,
     get_aging_report,
     get_ar_ap_subledger,
@@ -501,6 +502,7 @@ def _bool_arg(name: str) -> bool:
 
 def _financial_filters() -> FinancialReportFilters:
     company_code = _resolve_company(request.args.get("company", "cacao"))
+    show_cancellations = _bool_arg("show_cancellations")
     return FinancialReportFilters(
         company=company_code,
         ledger=request.args.get("ledger") or None,
@@ -515,7 +517,7 @@ def _financial_filters() -> FinancialReportFilters:
         party_type=request.args.get("party_type") or None,
         party_id=request.args.get("party_id") or None,
         voucher_type=request.args.get("voucher_type") or None,
-        status=request.args.get("status") or "submitted",
+        status=(request.args.get("status") or "submitted") if not show_cancellations else None,
         include_running_balance=_bool_arg("include_running_balance"),
         page=max(_int_arg("page", 1), 1),
         page_size=max(_int_arg("page_size", 100), 1),
@@ -523,6 +525,17 @@ def _financial_filters() -> FinancialReportFilters:
         sort_dir=request.args.get("sort_dir", "asc"),
         export_all=False,
     )
+
+
+def _should_run_financial_report() -> bool:
+    """Evita cargar datos al abrir la vista sin aplicar filtros explícitos."""
+    if request.args.get("apply_filters") in {"1", "true", "yes", "on"}:
+        return True
+    return "export" in request.args
+
+
+def _empty_financial_report() -> PaginatedReport:
+    return PaginatedReport(rows=[], totals={}, columns=[], total_rows=0, page=1, page_size=100, ledger_currency=None)
 
 
 def _report_to_matrix(report) -> tuple[list[str], list[list[object]]]:
@@ -661,16 +674,46 @@ def _render_financial_report(
     grouped_rows: list[dict[str, object]] = []
     if report_code == "account-movement" and group_by and group_by in display_columns:
         current_group = None
+        group_debit = Decimal("0")
+        group_credit = Decimal("0")
         for row in display_rows:
             group_value = row.get(group_by, _EMPTY_CELL_VALUE)
             if group_value != current_group:
+                if current_group is not None:
+                    grouped_rows.append(
+                        {
+                            "__row_type": "group_subtotal",
+                            "__group_title": _("Subtotal"),
+                            "debit": _format_cell("debit", group_debit, report.ledger_currency),
+                            "credit": _format_cell("credit", group_credit, report.ledger_currency),
+                        }
+                    )
                 group_row: dict[str, object] = {
                     "__row_type": "group",
                     "__group_title": f"{_(group_by.replace('_', ' ').title())}: {group_value}",
                 }
                 grouped_rows.append(group_row)
                 current_group = group_value
+                group_debit = Decimal("0")
+                group_credit = Decimal("0")
+            try:
+                group_debit += Decimal(str(row.get("debit", "0")).replace(",", "").replace("(", "-").replace(")", ""))
+            except DecimalException:
+                pass
+            try:
+                group_credit += Decimal(str(row.get("credit", "0")).replace(",", "").replace("(", "-").replace(")", ""))
+            except DecimalException:
+                pass
             grouped_rows.append(row)
+        if current_group is not None:
+            grouped_rows.append(
+                {
+                    "__row_type": "group_subtotal",
+                    "__group_title": _("Subtotal"),
+                    "debit": _format_cell("debit", group_debit, report.ledger_currency),
+                    "credit": _format_cell("credit", group_credit, report.ledger_currency),
+                }
+            )
     else:
         grouped_rows = display_rows
     display_totals = {key: _format_cell(key, value, report.ledger_currency) for key, value in report.totals.items()}
@@ -706,7 +749,7 @@ def _render_financial_report(
 def account_movement():
     """Reporte unificado de detalle de movimiento contable."""
     filters, selected_view, saved_views = _resolve_view_context("account-movement", _financial_filters())
-    report = get_account_movement_detail(filters)
+    report = get_account_movement_detail(filters) if _should_run_financial_report() else _empty_financial_report()
     if request.args.get("export") in {"csv", "xlsx"}:
         export_report = get_account_movement_detail(replace(filters, export_all=True, page=1))
         return _render_financial_report(
@@ -734,7 +777,7 @@ def account_movement():
 def trial_balance():
     """Reporte de balanza de comprobación."""
     filters, selected_view, saved_views = _resolve_view_context("trial-balance", _financial_filters())
-    report = get_trial_balance_report(filters)
+    report = get_trial_balance_report(filters) if _should_run_financial_report() else _empty_financial_report()
     return _render_financial_report(
         "trial-balance",
         _("Balanza de Comprobación"),
@@ -752,7 +795,7 @@ def trial_balance():
 def income_statement():
     """Reporte de estado de resultado."""
     filters, selected_view, saved_views = _resolve_view_context("income-statement", _financial_filters())
-    report = get_income_statement_report(filters)
+    report = get_income_statement_report(filters) if _should_run_financial_report() else _empty_financial_report()
     return _render_financial_report(
         "income-statement",
         _("Estado de Resultado"),
@@ -770,7 +813,7 @@ def income_statement():
 def balance_sheet():
     """Reporte de balance general."""
     filters, selected_view, saved_views = _resolve_view_context("balance-sheet", _financial_filters())
-    report = get_balance_sheet_report(filters)
+    report = get_balance_sheet_report(filters) if _should_run_financial_report() else _empty_financial_report()
     return _render_financial_report(
         "balance-sheet",
         _("Balance General"),

--- a/cacao_accounting/reportes/templates/reportes/financial_report.html
+++ b/cacao_accounting/reportes/templates/reportes/financial_report.html
@@ -54,7 +54,7 @@
   </ol>
 </nav>
 
-<div x-data="{ collapsed: false, advanced: false }" class="ca-report-layout">
+<div x-data="{ collapsed: false, advanced: {{ (request.args.get('advanced') == '1')|tojson }} }" class="ca-report-layout">
   <aside class="ca-report-filters ca-card" :class="{ 'ca-report-filters-collapsed': collapsed }">
     <div class="ca-card-header d-flex justify-content-between align-items-center">
       <h5 class="ca-card-title mb-0">{{ _("Filtros") }}</h5>
@@ -65,20 +65,30 @@
     </div>
     <div class="p-3" x-show="!collapsed">
       <form method="get" class="d-grid gap-2">
+        <input type="hidden" name="apply_filters" value="1">
+        <input type="hidden" name="advanced" :value="advanced ? '1' : '0'">
+                <div class="d-flex flex-wrap gap-2 mb-2">
+          <button class="btn btn-primary" type="submit">{{ _("Aplicar filtros") }}</button>
+          <a class="btn btn-outline-secondary" href="{{ request.path }}">{{ _("Limpiar filtros") }}</a>
+        </div>
         <label class="form-label mb-0">
           {{ _("Vista guardada") }}
           <div class="d-flex gap-2">
-            <input name="saved_view" class="form-control" value="{{ saved_view }}">
+            <input name="saved_view" class="form-control" list="saved-views-list" value="{{ saved_view }}">
+            <datalist id="saved-views-list">
+              {% for view_name in saved_views %}
+              <option value="{{ view_name }}"></option>
+              {% endfor %}
+            </datalist>
             <button class="btn btn-outline-secondary" type="submit" name="view_action" value="apply">{{ _("Cargar") }}</button>
+            <button class="btn btn-outline-secondary" type="button" data-bs-toggle="modal" data-bs-target="#saveViewModal">{{ _("Guardar") }}</button>
+            <button class="btn btn-outline-danger" type="submit" name="view_action" value="reset">{{ _("Eliminar") }}</button>
           </div>
-          {% if saved_views %}
-          <small class="text-muted">{{ _("Disponibles") }}: {{ saved_views|join(", ") }}</small>
-          {% endif %}
         </label>
         {{ smart_select_field("Compañía", "company", "company", request.args.get('company', 'cacao'), "report-company") }}
         {{ smart_select_field("Libro contable", "ledger", "book", request.args.get('ledger', ''), "report-ledger", 1, {"company": {"selector": "#report-company"}}, ["#report-company"], ["company"]) }}
         {{ smart_select_field("Periodo contable", "accounting_period", "accounting_period", request.args.get('accounting_period', ''), "report-accounting-period", 1, {"company": {"selector": "#report-company"}}, ["#report-company"], ["company"]) }}
-        {{ smart_select_field("ID visible del comprobante", "voucher_number", "document_no", request.args.get('voucher_number', ''), "report-voucher-number", 1, {"company": {"selector": "#report-company"}, "ledger": {"selector": "#report-ledger"}}, ["#report-company", "#report-ledger"], ["company"]) }}
+        {{ smart_select_field("Comprobante", "voucher_number", "document_no", request.args.get('voucher_number', ''), "report-voucher-number", 0, {"company": {"selector": "#report-company"}, "ledger": {"selector": "#report-ledger"}}, ["#report-company", "#report-ledger"], ["company"]) }}
         {{ smart_select_field("Cuenta contable", "account_code", "account_code", request.args.get('account_code', ''), "report-account-code", 1, {"company": {"selector": "#report-company"}}, ["#report-company"], ["company"]) }}
         <button class="btn btn-link text-start p-0 mt-1" type="button" @click="advanced = !advanced">
           <span x-show="!advanced">{{ _("Mostrar filtros avanzados") }}</span>
@@ -90,9 +100,9 @@
           {{ smart_select_field("Centro de costos", "cost_center_code", "cost_center", request.args.get('cost_center_code', ''), "report-cost-center", 1, {"company": {"selector": "#report-company"}}, ["#report-company"], ["company"]) }}
           {{ smart_select_field("Unidad de negocio", "unit_code", "unit", request.args.get('unit_code', ''), "report-unit", 1, {"company": {"selector": "#report-company"}}, ["#report-company"], ["company"]) }}
           {{ smart_select_field("Proyecto", "project_code", "project", request.args.get('project_code', ''), "report-project", 1, {"company": {"selector": "#report-company"}}, ["#report-company"], ["company"]) }}
-          {{ smart_select_field("Tipo de tercero", "party_type", "party_type", request.args.get('party_type', ''), "report-party-type") }}
+          {{ smart_select_field("Tipo de tercero", "party_type", "party_type", request.args.get('party_type', ''), "report-party-type", 0) }}
           {{ smart_select_field("Tercero", "party_id", "party", request.args.get('party_id', ''), "report-party-id", 1, {"company": {"selector": "#report-company"}, "party_type": {"selector": "#report-party-type"}}, ["#report-company", "#report-party-type"], ["company"]) }}
-          {{ smart_select_field("Tipo de comprobante", "voucher_type", "voucher_type", request.args.get('voucher_type', ''), "report-voucher-type", 1, {"company": {"selector": "#report-company"}, "ledger": {"selector": "#report-ledger"}}, ["#report-company", "#report-ledger"], ["company"]) }}
+          {{ smart_select_field("Tipo de comprobante", "voucher_type", "voucher_type", request.args.get('voucher_type', ''), "report-voucher-type", 0, {"company": {"selector": "#report-company"}, "ledger": {"selector": "#report-ledger"}}, ["#report-company", "#report-ledger"], ["company"]) }}
           {{ smart_select_field("Estado", "status", "report_status", request.args.get('status', 'submitted'), "report-status") }}
           <label class="form-label mb-0">
             {{ _("Agrupar por") }}
@@ -107,20 +117,16 @@
               <option value="accounting_period" {% if group_by == 'accounting_period' %}selected{% endif %}>{{ _("Periodo") }}</option>
             </select>
           </label>
-          <div class="border rounded p-2">
-            <div class="fw-semibold mb-2">{{ _("Columnas visibles") }}</div>
-            {% for available in all_columns %}
-            <label class="form-check">
-              <input class="form-check-input" type="checkbox" name="visible_columns" value="{{ available }}" {% if available in selected_columns %}checked{% endif %}>
-              <span class="form-check-label">{{ display_headers.get(available, available) }}</span>
-            </label>
-            {% endfor %}
-          </div>
+          <label class="form-check">
+            <input class="form-check-input" type="checkbox" name="show_cancellations" value="1" {% if request.args.get('show_cancellations') in ('1','true','on','yes') %}checked{% endif %}>
+            <span class="form-check-label">{{ _("Mostrar anulaciones") }}</span>
+          </label>
+          <button type="button" class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#columnsModal">{{ _("Columnas visibles") }}</button>
         </div>
         <div class="d-flex flex-wrap gap-2 mt-2">
           <button class="btn btn-primary" type="submit">{{ _("Aplicar filtros") }}</button>
           <a class="btn btn-outline-secondary" href="{{ request.path }}">{{ _("Limpiar filtros") }}</a>
-          <button class="btn btn-outline-secondary" type="submit" name="view_action" value="save">{{ _("Guardar vista") }}</button>
+          <button class="btn btn-outline-secondary" type="button" data-bs-toggle="modal" data-bs-target="#saveViewModal">{{ _("Guardar vista") }}</button>
           <button class="btn btn-outline-danger" type="submit" name="view_action" value="reset">{{ _("Eliminar vista") }}</button>
         </div>
       </form>
@@ -158,6 +164,20 @@
           <tr class="table-light">
             <td colspan="{{ columns|length if columns else 1 }}" class="fw-semibold">{{ row.get('__group_title') }}</td>
           </tr>
+          {% elif row.get('__row_type') == 'group_subtotal' %}
+          <tr class="table-secondary">
+            {% for column in columns %}
+            {% if loop.first %}
+            <td class="fw-semibold">{{ row.get('__group_title') }}</td>
+            {% elif column == 'debit' %}
+            <td class="text-end fw-semibold">{{ row.get('debit', "—") }}</td>
+            {% elif column == 'credit' %}
+            <td class="text-end fw-semibold">{{ row.get('credit', "—") }}</td>
+            {% else %}
+            <td>—</td>
+            {% endif %}
+            {% endfor %}
+          </tr>
           {% else %}
             {% set meta = row.get('__meta') %}
           <tr class="{% if meta and meta.is_group %}ca-group-row{% endif %}">
@@ -193,11 +213,45 @@
         <strong class="ca-total-value">{{ value }}</strong>
       </div>
       {% endfor %}
-      {% if is_balanced %}
-      <div class="ca-total-item ca-total-ok">{{ _("Cuadrado") }}</div>
-      {% endif %}
-    </div>
+          </div>
   </section>
+</div>
+
+<div class="modal fade" id="saveViewModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header"><h5 class="modal-title">{{ _("Guardar vista") }}</h5></div>
+      <div class="modal-body">
+        <label class="form-label">{{ _("Nombre de vista") }}</label>
+        <input class="form-control" id="save-view-name" value="{{ saved_view }}">
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ _("Cancelar") }}</button>
+        <button type="button" class="btn btn-primary" id="save-view-confirm">{{ _("Guardar") }}</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="columnsModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header"><h5 class="modal-title">{{ _("Columnas visibles") }}</h5></div>
+      <div class="modal-body">
+        <div class="row row-cols-2">
+          {% for available in all_columns + ["reference_type", "is_reversal", "reversal_of"] %}
+          <label class="form-check col">
+            <input class="form-check-input" type="checkbox" name="visible_columns" form="financial-filter-form" value="{{ available }}" {% if available in selected_columns %}checked{% endif %}>
+            <span class="form-check-label">{{ display_headers.get(available, available) }}</span>
+          </label>
+          {% endfor %}
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ _("Cerrar") }}</button>
+      </div>
+    </div>
+  </div>
 </div>
 
 <style>
@@ -223,6 +277,24 @@
 
 <script>
   document.addEventListener('DOMContentLoaded', function () {
+    const filterForm = document.querySelector('.ca-report-filters form');
+    if (filterForm) {
+      filterForm.id = 'financial-filter-form';
+    }
+    const saveViewConfirm = document.getElementById('save-view-confirm');
+    const saveViewName = document.getElementById('save-view-name');
+    if (saveViewConfirm && saveViewName && filterForm) {
+      saveViewConfirm.addEventListener('click', function () {
+        const savedViewInput = filterForm.querySelector('input[name=\"saved_view\"]');
+        if (savedViewInput) savedViewInput.value = saveViewName.value || '';
+        const hiddenAction = document.createElement('input');
+        hiddenAction.type = 'hidden';
+        hiddenAction.name = 'view_action';
+        hiddenAction.value = 'save';
+        filterForm.appendChild(hiddenAction);
+        filterForm.submit();
+      });
+    }
     const rows = Array.from(document.querySelectorAll('.ca-report-table tbody tr'));
     rows.forEach(function (row) {
       const cell = row.querySelector('td[data-code]');

--- a/cacao_accounting/search_select.py
+++ b/cacao_accounting/search_select.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any, Callable, Sequence
 
 from sqlalchemy import Select, case, cast, func, or_, select, true
@@ -119,7 +120,19 @@ def _string_label(value: Any) -> str:
     return str(value)
 
 
-SEARCH_SELECT_REGISTRY: dict[str, SearchSelectSpec] = {
+def _party_type_label(party: Party) -> str:
+    return str(getattr(party, "party_type", "") or "")
+
+
+def _voucher_type_label(entry: GLEntry) -> str:
+    return str(getattr(entry, "voucher_type", "") or "")
+
+
+def _document_no_label(entry: GLEntry) -> str:
+    return str(getattr(entry, "document_no", "") or getattr(entry, "voucher_id", "") or "")
+
+
+_SEARCH_SELECT_REGISTRY: dict[str, SearchSelectSpec] = {
     "company": SearchSelectSpec(
         doctype="company",
         model=Entity,
@@ -269,7 +282,7 @@ SEARCH_SELECT_REGISTRY: dict[str, SearchSelectSpec] = {
         model=Party,
         search_fields=("party_type",),
         value_field="party_type",
-        label_builder=_string_label,
+        label_builder=_party_type_label,
         allowed_filters={"is_active": "is_active"},
         default_filters={"is_active": True},
         deduplicate_by_value=True,
@@ -279,7 +292,7 @@ SEARCH_SELECT_REGISTRY: dict[str, SearchSelectSpec] = {
         model=GLEntry,
         search_fields=("voucher_type",),
         value_field="voucher_type",
-        label_builder=_string_label,
+        label_builder=_voucher_type_label,
         allowed_filters={"company": "company", "ledger": "ledger_id"},
         default_filters={},
         deduplicate_by_value=True,
@@ -289,12 +302,13 @@ SEARCH_SELECT_REGISTRY: dict[str, SearchSelectSpec] = {
         model=GLEntry,
         search_fields=("document_no", "voucher_id"),
         value_field="document_no",
-        label_builder=_string_label,
+        label_builder=_document_no_label,
         allowed_filters={"company": "company", "ledger": "ledger_id"},
         default_filters={},
         deduplicate_by_value=True,
     ),
 }
+SEARCH_SELECT_REGISTRY = MappingProxyType(_SEARCH_SELECT_REGISTRY)
 
 
 def search_select(doctype: str, query: str, filters: dict[str, list[str]], limit: int | None = None) -> dict[str, Any]:


### PR DESCRIPTION
### Motivation
- Evitar regressiones y cerrar múltiples `FIXME` relacionados con los reportes financieros, conciliación bancaria, generación de identificadores y seguridad de formularios. 
- Mejorar la experiencia de filtros/columnas, performance al cargar reportes y la consistencia de saldos en subledger tras cancelaciones de pagos.

### Description
- Reportes: agrega `apply_filters` para evitar cargar datos al abrir la vista, añade `show_cancellations` para incluir anulaciones, soporte de `group_by` con subtotales por agrupador, modal de `Columnas visibles`, modal para guardar vistas y persistencia/acciones (`save/apply/reset`), y evita carga de datos a menos que se aplique filtros o se exporte via `_should_run_financial_report`/`_empty_financial_report`.
- UI/UX: ajustes en `financial_report.html` para botones de aplicar/limpiar arriba/abajo, toggle avanzado persistente (`advanced`), renombrado de filtro a `Comprobante`, y ajustes de `smart_select` para ciertos campos con `minChars=0` y listados de vistas.
- Bancos: en creación de pago valida que `allocated == amount` cuando hay asignaciones y en cancelación elimina `PaymentReference` y refresca el cache de saldos pendientes via `refresh_outstanding_amount_cache` para mantener consistencia subledger/GL.
- Secuencias/identificadores: `generate_identifier` ahora invoca `should_reset_sequence` y `reset_sequence` antes de incrementar la secuencia cuando aplica.
- Seguridad/CSRF: añade token oculto en `admin/taxes.html` y envía header `X-CSRFToken` para `PUT/DELETE` de preferencias en `journal_nuevo.html`.
- Refactors y correcciones: `validar_clave_segura` refactorizado con `match/case`; `Entity` endpoints corregidos para usar `enabled`/`default`; `SPECIAL_ACCOUNT_TYPES` ampliado con tipos base (`asset`, `liability`, `equity`, `income`, `expense`).
- `search_select`: corrige etiquetas para evitar renderizar objetos en filtros de tercero/tipo comprobante/comprobante (`party_type`, `voucher_type`, `document_no`) y convierte el registro en solo lectura usando `MappingProxyType`.

### Testing
- Se ejecutó construcción y linters con `python -m build`, `python -m flake8`, `python -m ruff check cacao_accounting/` y `python -m mypy cacao_accounting/` y no reportaron errores.
- Suite de tests automatizados ejecutada con `CACAO_TEST=True LOGURU_LEVEL=WARNING SECRET_KEY=ASD123kljaAddS python -m pytest -v -s --exitfirst --slow=True` y las pruebas relevantes incluidas en `tests/test_08_reconciliation_reports.py` (validación de exportación XLSX y persistencia de vistas) pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00f9c23cbc8332a5e0d4097699ce69)